### PR TITLE
feat(MRK-7): Integrate Kingfisher for image loading

### DIFF
--- a/Marko/Features/Home/TeacherCollectionViewCell.swift
+++ b/Marko/Features/Home/TeacherCollectionViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 
 class TeacherCollectionViewCell: UICollectionViewCell {
     
@@ -160,19 +161,23 @@ class TeacherCollectionViewCell: UICollectionViewCell {
     // MARK: - Public Configuration
     
     public func configure(with teacher: Teacher) {
-        // In a future ticket, this is where we will use Kingfisher
-        // For now, we can test with a local or system image
-        // teacherImageView.image = UIImage(named: "somePlaceholder")
         
         nameLabel.text = teacher.name
         headlineLabel.text = teacher.headline
         ratingLabel.text = "\(teacher.rating) (\(teacher.reviewCount) reviews)"
         priceLabel.text = "$\(teacher.hourlyRate)/hr"
+        
+        let url = URL(string: teacher.profileImageURL)
+        let placeholder = UIImage(systemName: "person.crop.rectangle.stack")
+        teacherImageView.kf.setImage(with: url, placeholder: placeholder)
     }
     
     // It's good practice to reset content for cell reuse
     override func prepareForReuse() {
         super.prepareForReuse()
+        
+        teacherImageView.kf.cancelDownloadTask()
+        
         teacherImageView.image = nil
         nameLabel.text = nil
         headlineLabel.text = nil

--- a/Podfile
+++ b/Podfile
@@ -7,5 +7,5 @@ target 'Marko' do
   pod 'FirebaseFirestore', '~> 8.0'
   pod 'Firebase/Storage', '~> 8.0'  # For teacher photos
   pod 'FirebaseAuth', '~> 8.0'
-# pod 'Kingfisher', '~> 6.0'
+  pod 'Kingfisher', '~> 6.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -769,6 +769,7 @@ PODS:
     - Libuv-gRPC (= 0.0.10)
   - gRPC-Core/Interface (1.44.0)
   - GTMSessionFetcher/Core (1.7.2)
+  - Kingfisher (6.3.1)
   - leveldb-library (1.22.6)
   - Libuv-gRPC (0.0.10):
     - Libuv-gRPC/Implementation (= 0.0.10)
@@ -789,6 +790,7 @@ DEPENDENCIES:
   - Firebase/Storage (~> 8.0)
   - FirebaseAuth (~> 8.0)
   - FirebaseFirestore (~> 8.0)
+  - Kingfisher (~> 6.0)
 
 SPEC REPOS:
   trunk:
@@ -808,6 +810,7 @@ SPEC REPOS:
     - "gRPC-C++"
     - gRPC-Core
     - GTMSessionFetcher
+    - Kingfisher
     - leveldb-library
     - Libuv-gRPC
     - nanopb
@@ -830,11 +833,12 @@ SPEC CHECKSUMS:
   "gRPC-C++": 9675f953ace2b3de7c506039d77be1f2e77a8db2
   gRPC-Core: 943e491cb0d45598b0b0eb9e910c88080369290b
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
+  Kingfisher: 016c8b653a35add51dd34a3aba36b580041acc74
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   Libuv-gRPC: 55e51798e14ef436ad9bc45d12d43b77b49df378
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
 
-PODFILE CHECKSUM: f179cc36ec2b4304626630d0cc6b8640322c37f8
+PODFILE CHECKSUM: 0f6f074370acdd186090280f6ca192c61cfb1741
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
Description

This Pull Request integrates the Kingfisher library to handle all asynchronous image loading for the teacher list. It resolves ticket MRK-7 by replacing the previous placeholder implementation with a robust, cache-enabled solution.
Changes Made

    Dependency: Added Kingfisher (~> 6.3.1) to the Podfile.

    TeacherCollectionViewCell:

        The configure(with:) method now uses kf.setImage(with:) to download and display the teacher's profile image from the provided URL.

        The prepareForReuse() method has been updated to include kf.cancelDownloadTask() to prevent incorrect images from appearing during fast scrolling and to conserve network resources.

    Project Compatibility: This change was implemented and tested with the specified Kingfisher version to ensure compatibility with our Xcode 12.4 / Swift 5.3 environment.

Confluence Documentation

The implementation details have been updated on the main feature documentation page:

https://markoschool.atlassian.net/wiki/x/AoBQB