### PR TITLE
feat(MRK-8): Implement custom navigation bar in HomeVC

### DIFF
--- a/Marko/Features/Home/HomeVC.swift
+++ b/Marko/Features/Home/HomeVC.swift
@@ -21,6 +21,35 @@ class HomeVC: UIViewController {
         return cv
     }()
     
+    let lessonsButton: UIButton = {
+        let bt = UIButton(type: .system)
+        
+        // style the button
+        bt.setTitle("My Lessons 2", for: .normal) // For now, we'll hardcode the "2". Later, this will come from a ViewModel.
+        bt.backgroundColor = .systemBlue
+        bt.setTitleColor(.white, for: .normal)
+        bt.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .bold)
+        
+        // make it pill-shaped
+        bt.layer.cornerRadius = 15
+        
+        // some padding inside the button
+        bt.contentEdgeInsets = UIEdgeInsets(top: 8, left: 16, bottom: 9, right: 16)
+        
+        bt.translatesAutoresizingMaskIntoConstraints = false
+        return bt
+    }()
+    
+    
+    let profileButton: UIButton = {
+        let bt = UIButton(type: .system)
+        bt.setTitle("AB", for: .normal) // it temoparily placeholder
+        bt.setTitleColor(.label, for: .normal) // lable works both light and dark
+        bt.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .bold)
+        bt.translatesAutoresizingMaskIntoConstraints = false
+        return bt
+    }()
+    
     
     init(vm: HomeViewModel) {
         self.homeViewModel = vm
@@ -35,6 +64,7 @@ class HomeVC: UIViewController {
         super.viewDidLoad()
         
         setupUI()
+        setupNavBar()
         setupConstraints()
         
         homeViewModel.closureOutlet = { [weak self] in
@@ -48,7 +78,6 @@ class HomeVC: UIViewController {
         
         homeViewModel.fetchTeachers()
         view.backgroundColor = .systemGray6
-        
     }
     
     private func setupUI() {
@@ -57,6 +86,19 @@ class HomeVC: UIViewController {
 
         collectionView.delegate = self
         collectionView.dataSource = self
+    }
+    
+    private func setupNavBar() {
+        
+        let titleLabel = UILabel()
+        titleLabel.text = "Marko School"
+        titleLabel.font = UIFont.systemFont(ofSize: 22, weight: .bold)
+        titleLabel.textColor = .label
+        
+        let lessonBarItem = UIBarButtonItem(customView: lessonsButton)
+        let profileBarItem = UIBarButtonItem(customView: profileButton)
+        navigationItem.rightBarButtonItems = [profileBarItem, lessonBarItem]
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: titleLabel)
     }
     
     private func setupConstraints() {
@@ -69,8 +111,6 @@ class HomeVC: UIViewController {
         
     }
 }
-
-
 
 
 extension HomeVC: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {


### PR DESCRIPTION
Overview

This PR implements the custom navigation bar for the HomeViewController as defined in ticket MRK-8. It replaces the default centered title with a custom, left-aligned title and adds placeholders for the "My Lessons" and "Account" buttons on the right.

This is a purely visual change to establish the foundational UI for the main screen. The new buttons do not have actions attached yet.

Jira Ticket

    Closes: [MRK-8](https://www.google.com/url?sa=E&q=https%3A%2F%2Fmarkoschool.atlassian.net%2Fbrowse%2FMRK-8)

Documentation

The relevant Confluence documentation for the Home Screen feature has been updated to include details about this new custom navigation bar implementation.

    Confluence Page:
 
https://markoschool.atlassian.net/wiki/x/AoBQB

Changes

    Modified HomeVC.swift to configure navigationItem.leftBarButtonItem and navigationItem.rightBarButtonItems.

    Created and styled custom UIButtons to serve as the new navigation items.

Testing

    Verified on an iPhone 8 (iOS 14.4) simulator.

    Confirmed that the title is left-aligned and the buttons appear correctly on the right.

    Confirmed that the rest of the UI (the collection view) is unaffected.

[MRK-8]: https://markoschool.atlassian.net/browse/MRK-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ