### PR TITLE
feat(MRK-10): Pass teacher data to detail screen and display headline

### DIFF
--- a/Marko/Features/TeacherDetail/TeacherDetailVC.swift
+++ b/Marko/Features/TeacherDetail/TeacherDetailVC.swift
@@ -11,6 +11,17 @@ class TeacherDetailVC: UIViewController {
     
     private let vm: TeacherDetailVM
     
+    private let headlineLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 18, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+
     init(vm: TeacherDetailVM) {
         self.vm = vm
         super.init(nibName: nil, bundle: nil)
@@ -25,8 +36,27 @@ class TeacherDetailVC: UIViewController {
         
         view.backgroundColor = .systemBackground
         title = vm.teacher.name
+        
+        
+        view.addSubview(headlineLabel)
+        
+        headlineLabel.text = vm.teacher.headline
+        
+        setupConstraints()
+        
     }
     
-    
-    
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            // Center the label horizontally in the view
+            headlineLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            
+            // Position it 150 points from the top of the safe area
+            headlineLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 150),
+            
+            // Add left and right padding so it doesn't touch the edges
+            headlineLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            headlineLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
+        ])
+    }
 }


### PR DESCRIPTION
Overview

    This PR wires up the data flow for the Teacher Detail screen, as defined in MRK-10.

    It ensures that the Teacher object selected on the home screen is successfully passed through the coordinator to the TeacherDetailViewModel and is accessible by the TeacherDetailVC for display.

    Jira Ticket

        Closes: MRK-10

    Documentation

        The Confluence page for this feature has been updated with the data flow logic: 

https://markoschool.atlassian.net/wiki/x/AQBxB
