### PR TITLE
feat(MRK-11): Create AuthService singleton shell and listener

### DIFF
--- a/Marko.xcodeproj/project.pbxproj
+++ b/Marko.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		FA647F9A2E61ECBB000C2FE5 /* MarkoCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA647F992E61ECBB000C2FE5 /* MarkoCoreTests.swift */; };
 		FA7A51A92E5E74A800CF9A31 /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7A51A82E5E74A800CF9A31 /* MainCoordinator.swift */; };
 		FA7A51AC2E5E74BB00CF9A31 /* CoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7A51AB2E5E74BB00CF9A31 /* CoordinatorProtocol.swift */; };
+		FA7C2AE42E762F0700473D84 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7C2AE32E762F0700473D84 /* AuthService.swift */; };
 		FA904C662E67549B008254C4 /* TeacherRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA904C652E67549B008254C4 /* TeacherRepository.swift */; };
 		FA9D97B42E6A404C00A475E7 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9D97B32E6A404C00A475E7 /* HomeViewModel.swift */; };
 		FA9D97B72E6A5FCC00A475E7 /* HomeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9D97B62E6A5FCC00A475E7 /* HomeVC.swift */; };
@@ -44,6 +45,7 @@
 		FA647F992E61ECBB000C2FE5 /* MarkoCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkoCoreTests.swift; sourceTree = "<group>"; };
 		FA7A51A82E5E74A800CF9A31 /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 		FA7A51AB2E5E74BB00CF9A31 /* CoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorProtocol.swift; sourceTree = "<group>"; };
+		FA7C2AE32E762F0700473D84 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		FA904C652E67549B008254C4 /* TeacherRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherRepository.swift; sourceTree = "<group>"; };
 		FA9D97B32E6A404C00A475E7 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		FA9D97B62E6A5FCC00A475E7 /* HomeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVC.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 		FA7A51A02E5E73A500CF9A31 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				FA7C2AE32E762F0700473D84 /* AuthService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -354,6 +357,7 @@
 				FA30CE622E5530FD0053783F /* AppDelegate.swift in Sources */,
 				FAFE88E92E6C6E4700B1BD91 /* TeacherCollectionViewCell.swift in Sources */,
 				FA904C662E67549B008254C4 /* TeacherRepository.swift in Sources */,
+				FA7C2AE42E762F0700473D84 /* AuthService.swift in Sources */,
 				FAFFF5072E66002A007B0644 /* TimeSlot.swift in Sources */,
 				FA7A51A92E5E74A800CF9A31 /* MainCoordinator.swift in Sources */,
 				FA7A51AC2E5E74BB00CF9A31 /* CoordinatorProtocol.swift in Sources */,

--- a/Marko/Application/AppDelegate.swift
+++ b/Marko/Application/AppDelegate.swift
@@ -14,6 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
+        
+        let _ = AuthService.shared
+        
         return true
     }
 

--- a/Marko/Services/AuthService.swift
+++ b/Marko/Services/AuthService.swift
@@ -1,0 +1,43 @@
+//
+//  AuthService.swift
+//  Marko
+//
+//  Created by Ivan on 14.09.2025.
+//
+
+import Foundation
+import Firebase
+
+class AuthService {
+    
+    static let shared = AuthService()
+    
+    private var authStateHandle: AuthStateDidChangeListenerHandle?
+    
+    private init() {
+        
+        addAuthStateListener()
+    }
+    
+    private func addAuthStateListener() {
+        
+        authStateHandle = Auth.auth().addStateDidChangeListener({ [weak self] auth, user in
+            if let user = user {
+                print("AuthService: User is signed in with UID: \(user.uid)")
+            } else {
+                
+                print("AuthService: User is signed out.")
+            }
+            
+        })
+        
+    }
+    
+    deinit {
+        if let handle = authStateHandle {
+            Auth.auth().removeStateDidChangeListener(handle)
+            print("AuthService: Auth state listener removed.")
+        }
+    }
+    
+}


### PR DESCRIPTION
Overview

    This PR introduces the AuthService singleton, a crucial architectural component for managing the user's authentication state, as defined in MRK-11.

    The service establishes a single source of truth by using Firebase's addStateDidChangeListener. For now, it only prints the auth status to the console upon app launch.

    Jira Ticket

        Closes: MRK-11

    Documentation

        The new Confluence page for this service has been created:

https://markoschool.atlassian.net/wiki/x/BIB6B